### PR TITLE
Basic version working, tests missing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,50 +1,12 @@
-*.gem
-*.rbc
-/.config
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
 /coverage/
-/InstalledFiles
+/doc/
 /pkg/
 /spec/reports/
-/spec/examples.txt
-/test/tmp/
-/test/version_tmp/
 /tmp/
 
-# Used by dotenv library to load environment variables.
-# .env
-
-## Specific to RubyMotion:
-.dat*
-.repl_history
-build/
-*.bridgesupport
-build-iPhoneOS/
-build-iPhoneSimulator/
-
-## Specific to RubyMotion (use of CocoaPods):
-#
-# We recommend against adding the Pods directory to your .gitignore. However
-# you should judge for yourself, the pros and cons are mentioned at:
-# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
-#
-# vendor/Pods/
-
-## Documentation cache and generated files:
-/.yardoc/
-/_yardoc/
-/doc/
-/rdoc/
-
-## Environment normalization:
-/.bundle/
-/vendor/bundle
-/lib/bundler/man/
-
-# for a library or gem, you might want to ignore these files since the code is
-# intended to run in multiple environments; otherwise, check them in:
-# Gemfile.lock
-# .ruby-version
-# .ruby-gemset
-
-# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
-.rvmrc
+# rspec failure tracking
+.rspec_status

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+sudo: false
+language: ruby
+rvm:
+  - 2.3.1
+before_install: gem install bundler -v 1.14.6

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in rails-flytrap.gemspec
+gemspec

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rails Flytrap
 
-Flytrap is an exception handler for Rails JSON APIs with the intended purpose of making error handling being very simple to handle.
+Flytrap is an exception handler for Rails JSON APIs with the intention of making error handling very simple.
 
 ## Installation
 
@@ -53,17 +53,12 @@ Then if `dummy?` returns `true`, the output you get is:
 {
   "error": {
     "message": "Oops! Something broke!",
-    "code": 1
+    "code": 1,
+    "class_name": "DummyException"
   }
 }
 ```
 with, of course, your 500 status code!
-
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,70 @@
-# rails-flytrap
-A basic exception handler for Rails APIs
+# Rails Flytrap
+
+Flytrap is an exception handler for Rails JSON APIs with the intended purpose of making error handling being very simple to handle.
+
+## Installation
+
+Add this line to your application's Gemfile:
+
+```ruby
+gem 'rails-flytrap'
+```
+
+And then execute:
+
+    $ bundle
+
+Or install it yourself as:
+
+    $ gem install rails-flytrap
+
+## Usage
+
+To use Flytrap, just include the Flytrap module in your base API controller to set it up as an exception handler.
+```ruby
+class ApplicationController
+  include Flytrap
+end
+```
+
+Once you have that set up, any class that extends `Flytrap::Exception` will be caught and spit out in JSON!
+
+For example, if you have:
+```ruby
+class DummyException < Flytrap::Exception
+  self.status_code = 500 # The status code to be returned alongside the JSON output
+  self.message = 'Oops! Something broke!' # A developer-friendly message
+  self.code = 1 # An arbitrary code for you to identify errors from your front-end!
+end
+```
+and some error flow in a controller:
+
+```ruby
+class SomeController < ApplicationController
+  def index
+    raise DummyException.new if dummy?
+    render json: { foo: 'bar' }
+  end
+end
+```
+
+Then if `dummy?` returns `true`, the output you get is:
+```json
+{
+  "error": {
+    "message": "Oops! Something broke!",
+    "code": 1
+  }
+}
+```
+with, of course, your 500 status code!
+
+## Development
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+## Contributing
+
+Bug reports and pull requests are welcome on GitHub at https://github.com/ilanusse/rails-flytrap.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'
+set -vx
+
+bundle install
+
+# Do any other automated setup that you need to do here

--- a/lib/flytrap.rb
+++ b/lib/flytrap.rb
@@ -1,0 +1,11 @@
+require 'flytrap/version'
+require 'flytrap/exception'
+
+module Flytrap
+
+  def self.included(controller)
+    controller.rescue_from Flytrap::Exception do |e|
+      render json: e.to_json, status: e.status_code
+    end
+  end
+end

--- a/lib/flytrap/exception.rb
+++ b/lib/flytrap/exception.rb
@@ -1,0 +1,19 @@
+module Flytrap
+  # Flytrap Base Exception. Every exception that extends this should define:
+  #  message - Developer-friendly error message
+  #  code - Unique error code for front-end error handling
+  #  status_code - The status code to respond with
+  class Exception < RuntimeError
+    class_attribute :message, :code, :status_code
+
+    def to_json
+      {
+        error: {
+          message: self.class.message,
+          code: self.class.code,
+          class_name: self.class.name
+        }
+      }
+    end
+  end
+end

--- a/lib/flytrap/version.rb
+++ b/lib/flytrap/version.rb
@@ -1,0 +1,3 @@
+module Flytrap
+  VERSION = '0.1.0'.freeze
+end

--- a/rails-flytrap.gemspec
+++ b/rails-flytrap.gemspec
@@ -1,0 +1,43 @@
+# coding: utf-8
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'flytrap/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'rails-flytrap'
+  spec.version       = Flytrap::VERSION
+  spec.authors       = ['ilanusse']
+  spec.email         = ['inakilanusse@gmail.com']
+
+  spec.summary       = ' A basic exception handler for Rails APIs '
+  spec.homepage      = 'https://github.com/ilanusse/rails-flytrap'
+
+  # Prevent pushing this gem to RubyGems.org.
+  # To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or
+  # delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  else
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
+  end
+
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  # DEV DEPENDENCIES
+  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec-rails', '~> 3.5'
+  spec.add_development_dependency 'rubocop', '~> 0.48.1'
+
+  # DEPENDENCIES
+  spec.add_dependency 'rails', '>= 4.0'
+end

--- a/spec/flytrap/flytrap_spec.rb
+++ b/spec/flytrap/flytrap_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe Rails::Flytrap do
+  it 'has a version number' do
+    expect(Rails::Flytrap::VERSION).not_to be nil
+  end
+
+  it 'does something useful' do
+    expect(false).to eq(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,18 @@
+# Configure Rails Environment
+ENV["RAILS_ENV"] = "test"
+
+require File.expand_path("../../spec/dummy/config/environment.rb", __FILE__)
+ActiveRecord::Migrator.migrations_paths = [File.expand_path("../../spec/dummy/db/migrate", __FILE__)]
+
+require 'rspec/rails'
+require 'bundler/setup'
+require 'rails/flytrap'
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
## Summary
Made a base exception handler for Rails JSON APIs. For use in the base controller.

## Details
If someone includes the module in the base controller, it uses ActiveSupport's [`rescue_from`](https://apidock.com/rails/ActiveSupport/Rescuable/ClassMethods/rescue_from) to catch all exceptions that extend from the gem's base error (`Flytrap::Exception`, which in turn extends from Ruby's `RuntimeError`)

## Known issues
No tests as of yet, but I've been fooling around manually with a test Rails app and it works fine.